### PR TITLE
Update deadsnakes ppa address

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
   become: true
 
 - name: Add deadsnakes repo
-  apt_repository: repo="ppa:fkrull/deadsnakes"
+  apt_repository: repo="ppa:deadsnakes/ppa"
   become: true
 
 - name: Install python


### PR DESCRIPTION
deadsnakes' ppa address changed, so the the previous version stopped working.